### PR TITLE
fix(auth): update trusted origins and remove CORS headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "next dev --turbopack -p 8080",
 		"build": "next build",
-		"start": "next start",
+		"start": "next start -p 8080",
 		"lint": "next lint",
 		"db:introspect": "drizzle-kit introspect",
 		"db:generate": "drizzle-kit generate",

--- a/src/lib/auth/better-auth.ts
+++ b/src/lib/auth/better-auth.ts
@@ -19,7 +19,11 @@ export const auth = betterAuth({
 	database: drizzleAdapter(db, { provider: "pg" }),
 	basePath: `/api/${config.SERVER_API_VERSION}/${config.SERVER_API_TYPE}/auth`,
 
-	trustedOrigins: [config.EXTENSION_ORIGIN!, "http://localhost:5173"],
+	trustedOrigins: [
+		config.EXTENSION_ORIGIN!,
+		"http://localhost:5173",
+		config.BASE_URL!,
+	],
 
 	// auth providers
 	emailAndPassword: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -115,17 +115,17 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 	// Add CORS headers for all /v1/rest/auth paths to expose the auth api
 	if (targetPath.startsWith("/api/v1/rest/auth")) {
 		const response = NextResponse.next();
-		response.headers.set(
-			"Access-Control-Allow-Origin",
-			// process.env.EXTENSION_ORIGIN!,
-			"http://localhost:5173",
-		);
-		response.headers.set("Access-Control-Allow-Credentials", "true");
-		response.headers.set("Access-Control-Allow-Methods", "GET, POST");
-		response.headers.set(
-			"Access-Control-Allow-Headers",
-			"Content-Type, Authorization",
-		);
+		// response.headers.set(
+		// 	"Access-Control-Allow-Origin",
+		// 	// process.env.EXTENSION_ORIGIN!,
+		// 	"http://localhost:5173",
+		// );
+		// response.headers.set("Access-Control-Allow-Credentials", "true");
+		// response.headers.set("Access-Control-Allow-Methods", "GET, POST");
+		// response.headers.set(
+		// 	"Access-Control-Allow-Headers",
+		// 	"Content-Type, Authorization",
+		// );
 
 		// Handle preflight requests
 		if (request.method === "OPTIONS") {


### PR DESCRIPTION
Update trusted origins in better-auth.ts to include BASE_URL and remove unnecessary CORS headers in middleware.ts to simplify the middleware logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated server start command to use port 8080 instead of the default port.
- **New Features**
	- Expanded the list of trusted origins for authentication requests to include an additional origin.
- **Refactor**
	- Commented out the setting of CORS headers for specific authentication API routes; preflight handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->