### PR TITLE
remove better-auth trusted origin

### DIFF
--- a/src/lib/auth/better-auth.ts
+++ b/src/lib/auth/better-auth.ts
@@ -20,11 +20,11 @@ export const auth = betterAuth({
 	database: drizzleAdapter(db, { provider: "pg" }),
 	basePath: `/api/${config.SERVER_API_VERSION}/${config.SERVER_API_TYPE}/auth`,
 
-	trustedOrigins: [
-		config.EXTENSION_ORIGIN!,
-		"http://localhost:5173",
-		config.BASE_URL!,
-	],
+	// trustedOrigins: [
+	// 	config.EXTENSION_ORIGIN!,
+	// 	"http://localhost:5173",
+	// 	config.BASE_URL!,
+	// ],
 
 	// auth providers
 	emailAndPassword: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated authentication configuration by removing the explicit trusted origins setting. This may impact which origins are recognized during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->