### PR TITLE
feat(search): add search data store and integrate with search modal

### DIFF
--- a/src/app/auth/onboard/_components/index.tsx
+++ b/src/app/auth/onboard/_components/index.tsx
@@ -43,8 +43,8 @@ function Walkthrough() {
 		}
 	};
 
-	const validateCurrentStep = () => {
-		switch (currentStep) {
+	const validateStep = (step: number) => {
+		switch (step) {
 			case 0: // Professional
 				if (!formData.selectedProfessions.length) {
 					setErrors({
@@ -86,7 +86,7 @@ function Walkthrough() {
 	};
 
 	const handleNext = () => {
-		if (!validateCurrentStep()) {
+		if (!validateStep(currentStep)) {
 			return;
 		}
 
@@ -103,6 +103,18 @@ function Walkthrough() {
 		}
 	};
 
+	const handleRowStepChange = (step: number) => {
+		for (let i = 0; i < step; i++) {
+			if (!validateStep(i)) {
+				setCurrentStep(i);
+				return;
+			}
+		}
+
+		setCurrentStep(step);
+		setErrors({});
+	};
+
 	const mutation = usePostUserSubscriptionMutation({
 		onSuccess: (data: any) => {
 			location.href = "/dashboard?page=resources"; // redirect to dashboard
@@ -113,7 +125,7 @@ function Walkthrough() {
 	});
 
 	const handleSubmit = () => {
-		if (!validateCurrentStep()) {
+		if (!validateStep(currentStep)) {
 			return;
 		}
 		console.log("Form submitted:", formData);
@@ -200,7 +212,7 @@ function Walkthrough() {
 							color="primary"
 							currentStep={currentStep}
 							steps={STEPS}
-							onStepChange={setCurrentStep}
+							onStepChange={handleRowStepChange}
 						/>
 					</div>
 

--- a/src/app/collection/[name]/_components/PublicCollections.tsx
+++ b/src/app/collection/[name]/_components/PublicCollections.tsx
@@ -1,0 +1,45 @@
+"use client";
+import Container from "@/components/layouts/Container";
+import Layout from "@/components/layouts/users/Layout";
+import { Avatar, Button } from "@heroui/react";
+import Link from "next/link";
+import React from "react";
+
+const PublicCollections = () => {
+	return (
+		<Layout>
+			<Container>
+				<div className="flex items-center justify-between gap-4">
+					<div className="flex flex-col gap-2">
+						<h1 className="font-PlayFairDisplay text-3xl font-semibold">
+							Page
+						</h1>
+						<div className="flex items-center gap-2">
+							<Avatar
+								name={"test"}
+								src={undefined}
+								className="h-5 w-5"
+								size="sm"
+							/>
+							<p className="text-xs text-zinc-600 dark:text-zinc-400">
+								{"test"}
+							</p>
+						</div>
+					</div>
+					<div>
+						<Button
+							as={Link}
+							href="/auth/login"
+							className="bg-violet text-white"
+							radius="full"
+						>
+							Login now
+						</Button>
+					</div>
+				</div>
+			</Container>
+		</Layout>
+	);
+};
+
+export default PublicCollections;

--- a/src/app/collection/[name]/page.tsx
+++ b/src/app/collection/[name]/page.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import PublicCollections from "./_components/PublicCollections";
+
+const Page = () => {
+	return <PublicCollections />;
+};
+
+export default Page;

--- a/src/app/resources/_components/modal/SearchModal.tsx
+++ b/src/app/resources/_components/modal/SearchModal.tsx
@@ -28,6 +28,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { reInitQueryParams } from "@/lib/utils";
 import { useRecentSearches } from "@/store/useRecentSearches";
 import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
+import { useSearchData } from "@/store/useSearchData";
 
 // Helper function to highlight matching text
 const HighlightedText = ({
@@ -75,6 +76,7 @@ const SearchFormModal = () => {
 
 	const router = useRouter();
 	const searchRef = useRef<HTMLInputElement>(null);
+	const { searchData } = useSearchData();
 
 	const {
 		name: modalName,
@@ -84,11 +86,6 @@ const SearchFormModal = () => {
 	} = useModal();
 
 	const searchDebounced = useDebounce(searchValue, 250);
-
-	const { data } = useGetPaginatedResourcesQuery({
-		page: 1,
-		limit: -1,
-	});
 
 	useKeyboardShortcut({ ctrlKey: true, key: "k" }, () => {
 		onOpenModal("Search Filter", null);
@@ -100,7 +97,7 @@ const SearchFormModal = () => {
 
 	const filteredResources = useMemo(
 		() =>
-			data?.data?.rows
+			searchData
 				?.filter((resource: any) => {
 					if (!searchDebounced) return false;
 					const searchLower = searchDebounced.toLowerCase();
@@ -110,7 +107,7 @@ const SearchFormModal = () => {
 					);
 				})
 				.slice(0, 5) || [],
-		[data?.data?.rows, searchDebounced],
+		[searchData, searchDebounced],
 	);
 
 	useEffect(() => {

--- a/src/components/modal/ShareModal.tsx
+++ b/src/components/modal/ShareModal.tsx
@@ -121,6 +121,7 @@ const ShareModal = () => {
 					setShareType={setShareType}
 					handleChange={handleChange}
 					data={data}
+					disabled={isLoadingShortUrl}
 				/>
 			</div>
 		);
@@ -135,6 +136,7 @@ const ShareModal = () => {
 					role={role}
 					setRole={setRole}
 					data={data}
+					disabled={isLoadingShortUrl}
 				/>
 			</div>
 		);
@@ -167,6 +169,7 @@ const ShareModal = () => {
 								sharedTo={sharedTo}
 								setSharedTo={setSharedTo}
 								type={data?.type}
+								disabled={isLoadingShortUrl}
 							/>
 						)}
 						<ShortUrlContainer

--- a/src/components/modal/components/ShareModal/access-level.tsx
+++ b/src/components/modal/components/ShareModal/access-level.tsx
@@ -24,6 +24,7 @@ type Props = {
 	data: any;
 	setShareType: (shareType: "private" | "public") => void;
 	handleChange: (e: any) => void;
+	disabled: boolean;
 };
 
 const AccessLevel = ({
@@ -31,6 +32,7 @@ const AccessLevel = ({
 	data,
 	setShareType,
 	handleChange,
+	disabled,
 }: Props) => {
 	const isSmallDevices = useMediaQuery({
 		query: "(max-width: 64rem)",
@@ -46,7 +48,7 @@ const AccessLevel = ({
 			classNames={{
 				wrapper: "flex gap-3",
 			}}
-			isDisabled={!!data?.restrictedTo}
+			isDisabled={!!data?.restrictedTo || disabled}
 		>
 			{ACCESS_LEVELS.map((level) => (
 				<Radio

--- a/src/components/modal/components/ShareModal/permission-level.tsx
+++ b/src/components/modal/components/ShareModal/permission-level.tsx
@@ -22,9 +22,16 @@ type Props = {
 	setRole: (role: "view" | "edit") => void;
 	data: any;
 	handleChange: (e: any) => void;
+	disabled: boolean;
 };
 
-const PermissionLevel = ({ role, setRole, data, handleChange }: Props) => {
+const PermissionLevel = ({
+	role,
+	setRole,
+	data,
+	handleChange,
+	disabled,
+}: Props) => {
 	return (
 		<Fragment>
 			<Spacer />
@@ -39,7 +46,7 @@ const PermissionLevel = ({ role, setRole, data, handleChange }: Props) => {
 				className="w-full"
 				defaultSelectedKeys={["view"]}
 				aria-label="Select permission level"
-				isDisabled={!!data?.restrictedTo}
+				isDisabled={!!data?.restrictedTo || disabled}
 				renderValue={(items) => {
 					return items.map((item) => {
 						const level = PERMISSION_LEVELS.find(

--- a/src/components/modal/components/ShareModal/shared-emails.tsx
+++ b/src/components/modal/components/ShareModal/shared-emails.tsx
@@ -17,9 +17,16 @@ type Props = {
 	setSharedTo: (value: Record<string, string>[]) => void;
 	type: "Resource" | "Collection";
 	handleChange: (e: any) => void;
+	disabled: boolean;
 };
 
-const SharedEmails = ({ sharedTo, setSharedTo, type, handleChange }: Props) => {
+const SharedEmails = ({
+	sharedTo,
+	setSharedTo,
+	type,
+	handleChange,
+	disabled,
+}: Props) => {
 	const [inputValue, setInputValue] = useState("");
 	const [error, setError] = useState("");
 	const [recentAddedEmails, setRecentAddedEmails] = useState<string[]>([]);
@@ -128,6 +135,7 @@ const SharedEmails = ({ sharedTo, setSharedTo, type, handleChange }: Props) => {
 						color={error ? "danger" : "default"}
 						isInvalid={!!error}
 						errorMessage={error}
+						isDisabled={disabled}
 						validate={(value) => {
 							if (
 								value &&
@@ -149,6 +157,7 @@ const SharedEmails = ({ sharedTo, setSharedTo, type, handleChange }: Props) => {
 						className="bg-violet text-white"
 						onPress={handleSendInvite}
 						radius="full"
+						isDisabled={disabled}
 					>
 						Send Invite
 					</Button>
@@ -182,7 +191,9 @@ const SharedEmails = ({ sharedTo, setSharedTo, type, handleChange }: Props) => {
 									<div className="flex items-center">
 										<Dropdown
 											placement="bottom-end"
-											isDisabled={type === "Resource"}
+											isDisabled={
+												type === "Resource" || disabled
+											}
 										>
 											<DropdownTrigger>
 												<Button
@@ -247,6 +258,7 @@ const SharedEmails = ({ sharedTo, setSharedTo, type, handleChange }: Props) => {
 											onPress={() =>
 												removeEmail(currentUser.email)
 											}
+											isDisabled={disabled}
 											className="text-default-500"
 										>
 											<X size={16} />

--- a/src/store/useSearchData.ts
+++ b/src/store/useSearchData.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+type SearchDataType = {
+	searchData: any;
+	setSearchData: (searchData: any) => void;
+	getSearchData: () => any;
+
+	reset: () => void;
+};
+
+export const useSearchData = create<SearchDataType>((set, get) => ({
+	searchData: null,
+	setSearchData: (searchData) => set({ searchData }),
+	getSearchData: () => get().searchData,
+
+	reset: () => set({ searchData: null }),
+}));


### PR DESCRIPTION
Introduce a new Zustand store useSearchData to manage search data globally. Update the search modal to use this store instead of fetching data directly. This improves performance by reducing redundant API calls and centralizes search data management. Additionally, disable form elements in the ShareModal during loading states to prevent user interaction conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a public collections page with user avatar and login button.
  - Added a global search data store for improved search experience.
- **Improvements**
  - Enhanced onboarding stepper: users must complete prior steps before advancing.
  - Updated resource search to use a global store, enabling more responsive and consistent search results.
  - Disabled sharing controls in the share modal while a short URL is loading, preventing unwanted interactions.
- **User Interface**
  - Improved disabling logic for access level, permission level, and shared emails components in sharing modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->