### PR TITLE
refactor(api): change id parameter type from number to string in routes

### DIFF
--- a/src/app/api/v1/rest/resource-collections/[id]/pin/route.ts
+++ b/src/app/api/v1/rest/resource-collections/[id]/pin/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const POST = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ id: number }> },
+	{ params }: { params: Promise<{ id: string }> },
 ) => {
 	const session = await getSession(req.headers);
 	const user = session?.user;
@@ -31,8 +31,11 @@ export const POST = async (
 			collection_id: exist[0].id,
 			user_id: user.id,
 		});
-		
-		return NextResponse.json({message: "Successfully pinned collection!", data: null}, {status: 200})
+
+		return NextResponse.json(
+			{ message: "Successfully pinned collection!", data: null },
+			{ status: 200 },
+		);
 	} catch (err) {
 		console.log(err);
 		return NextResponse.json({ message: "Server error" }, { status: 500 });
@@ -40,7 +43,7 @@ export const POST = async (
 };
 export const DELETE = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ id: number }> },
+	{ params }: { params: Promise<{ id: string }> },
 ) => {
 	const session = await getSession(req.headers);
 	const user = session?.user;
@@ -69,7 +72,10 @@ export const DELETE = async (
 					eq(pinned.user_id, user.id),
 				),
 			);
-		return NextResponse.json({message: "Successfully unpinned collection!", data: null}, {status: 200})
+		return NextResponse.json(
+			{ message: "Successfully unpinned collection!", data: null },
+			{ status: 200 },
+		);
 	} catch (err) {
 		console.log(err);
 		return NextResponse.json({ message: "Server error" }, { status: 500 });

--- a/src/app/api/v1/rest/resource-collections/[id]/public/route.ts
+++ b/src/app/api/v1/rest/resource-collections/[id]/public/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const GET = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ id: number | string }> },
+	{ params }: { params: Promise<{ id: string }> },
 ) => {
 	const { id } = await params;
 	const searchParams = req.nextUrl.searchParams;
@@ -18,7 +18,7 @@ export const GET = async (
 	const exist = await db
 		.select()
 		.from(collectionFolders)
-		.where(eq(collectionFolders.id, id as number));
+		.where(eq(collectionFolders.id, id));
 
 	if (!exist.length || exist[0].access_level !== "public") {
 		return NextResponse.json(
@@ -40,7 +40,7 @@ export const GET = async (
 					},
 				},
 			},
-			where: eq(collectionFolders.id, id as number),
+			where: eq(collectionFolders.id, id),
 		});
 
 		return [

--- a/src/app/api/v1/rest/resource-collections/[id]/route.ts
+++ b/src/app/api/v1/rest/resource-collections/[id]/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const PUT = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ id: number }> },
+	{ params }: { params: Promise<{ id: string }> },
 ) => {
 	const session = await getSession(req.headers);
 	const user = session?.user;

--- a/src/app/api/v1/rest/resource-collections/[id]/shorten/route.ts
+++ b/src/app/api/v1/rest/resource-collections/[id]/shorten/route.ts
@@ -10,7 +10,7 @@ import { uniqueSharedEmails } from "@/services/short-url-service";
 
 export const GET = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ id: number }> },
+	{ params }: { params: Promise<{ id: string }> },
 ) => {
 	const session = await getSession(req.headers);
 	const user = session?.user;
@@ -37,10 +37,7 @@ export const GET = async (
 				.from(collectionShortUrls)
 				.where(
 					and(
-						eq(
-							collectionShortUrls.collection_folder_id,
-							id as number,
-						),
+						eq(collectionShortUrls.collection_folder_id, id),
 						eq(collectionShortUrls.user_id, user.id),
 					),
 				)
@@ -78,13 +75,13 @@ export const GET = async (
 interface ShortenResourceRequest {
 	shared_to: Record<string, string>[];
 	access_level: "public" | "private" | "shared";
-	collection_folder_id?: number;
+	collection_folder_id?: string;
 	id?: string;
 }
 
 export const POST = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ id: number }> },
+	{ params }: { params: Promise<{ id: string }> },
 ) => {
 	const session = await getSession(req.headers);
 	const user = session?.user;
@@ -165,7 +162,7 @@ const createOrUpdateShortUrl = async (
 		const filter = [
 			eq(
 				collectionShortUrls.collection_folder_id,
-				requestData.collection_folder_id as number,
+				requestData.collection_folder_id as string,
 			),
 			eq(collectionShortUrls.user_id, userId),
 		];
@@ -189,7 +186,7 @@ const createOrUpdateShortUrl = async (
 				.where(
 					eq(
 						collectionFolders.id,
-						requestData.collection_folder_id as number,
+						requestData.collection_folder_id as string,
 					),
 				)
 				.returning({ name: collectionFolders.name });
@@ -226,7 +223,7 @@ const createOrUpdateShortUrl = async (
 			.values({
 				user_id: userId,
 				collection_folder_id:
-					requestData.collection_folder_id as number,
+					requestData.collection_folder_id as string,
 				short_code: shortCode,
 			})
 			.returning();

--- a/src/app/api/v1/rest/users/[id]/collection-resources/[collection_folder_id]/route.ts
+++ b/src/app/api/v1/rest/users/[id]/collection-resources/[collection_folder_id]/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const GET = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ collection_folder_id: number | string }> },
+	{ params }: { params: Promise<{ collection_folder_id: string }> },
 ) => {
 	const { collection_folder_id } = await params;
 	const searchParams = req.nextUrl.searchParams;
@@ -30,7 +30,7 @@ export const GET = async (
 			.where(
 				and(
 					eq(collectionFolders.user_id, user?.id),
-					eq(collectionFolders.id, collection_folder_id as number),
+					eq(collectionFolders.id, collection_folder_id),
 				),
 			);
 		if (!exist.length) {
@@ -51,7 +51,7 @@ export const GET = async (
 						eq(resourceCollections.user_id, user?.id),
 						eq(
 							resourceCollections.collection_folder_id,
-							collection_folder_id as number,
+							collection_folder_id,
 						),
 					),
 				);
@@ -63,7 +63,7 @@ export const GET = async (
 						eq(resourceCollections.user_id, user?.id),
 						eq(
 							resourceCollections.collection_folder_id,
-							collection_folder_id as number,
+							collection_folder_id,
 						),
 					),
 				);

--- a/src/app/api/v1/rest/users/[id]/collection-shared-resources/[collection_folder_id]/route.ts
+++ b/src/app/api/v1/rest/users/[id]/collection-shared-resources/[collection_folder_id]/route.ts
@@ -12,7 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const GET = async (
 	req: NextRequest,
-	{ params }: { params: Promise<{ collection_folder_id: number | string }> },
+	{ params }: { params: Promise<{ collection_folder_id: string }> },
 ) => {
 	const { collection_folder_id } = await params;
 	const searchParams = req.nextUrl.searchParams;


### PR DESCRIPTION
The id parameter in multiple API routes was updated from umber to string to ensure consistency and avoid type casting issues. This change simplifies the code and aligns with the expected data type in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated route parameters for collection and resource endpoints to consistently use string types instead of numbers. This change affects how IDs are handled across various endpoints but does not alter any functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->